### PR TITLE
Weaken assertion in validate

### DIFF
--- a/src/tracked_struct/struct_map.rs
+++ b/src/tracked_struct/struct_map.rs
@@ -118,7 +118,7 @@ where
 
         // Never update a struct twice in the same revision.
         let current_revision = runtime.current_revision();
-        assert!(data.created_at < current_revision);
+        assert!(data.created_at <= current_revision);
         data.created_at = current_revision;
     }
 
@@ -253,7 +253,7 @@ where
         drop(data);
 
         // Validate in current revision, if necessary.
-        if last_changed < runtime.current_revision() {
+        if created_at < runtime.current_revision() {
             Self::validate_in_map(map, runtime, id);
         }
 

--- a/tests/tracked_struct_not_validated_due_to_durability.rs
+++ b/tests/tracked_struct_not_validated_due_to_durability.rs
@@ -69,6 +69,7 @@ fn infer<'db>(db: &'db dyn Db, definition: Definition<'db>) -> Inference<'db> {
         infer(db, definitions(db, dependent_file).definition(db))
     } else {
         db.file(0).field(db);
+        index(db, file);
         Inference::new(db, definition)
     }
 }


### PR DESCRIPTION
Backport the last fix commit from https://github.com/salsa-rs/salsa/pull/550

It's now possible for `mark_validated_output` to be called on a struct that we already validated via `maybe_changed_after` on one of its fields, so `validate` can no longer assert that the struct is out of date.

This time I actually checked incremental run on tomllib locally with this change to ensure it works.